### PR TITLE
쿠키 충전, 거래 기록 조회 기능 추가

### DIFF
--- a/src/main/java/naver/webtoon/project/common/exception/ErrorCode.java
+++ b/src/main/java/naver/webtoon/project/common/exception/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
     PUBLIC_EPISODE_INACCESSIBILITY(HttpStatus.BAD_REQUEST, "EPISODE_007", "공개 에피소드는 접근 불가능합니다."),
     NOT_FOUND_INTERESTED_WEBTOON(HttpStatus.NOT_FOUND, "INTERESTED_WEBTOON_001", "찾을 수 없는 관심 웹툰입니다."),
     DUPLICATE_INTERESTED_WEBTOON(HttpStatus.BAD_REQUEST, "INTERESTED_WEBTOON_002", "관심 웹툰은 중복될 수 없습니다."),
+    DEFICIENT_POINT(HttpStatus.BAD_REQUEST, "POINT_001", "포인트가 부족합니다."),
 
     ;
 

--- a/src/main/java/naver/webtoon/project/member/entity/Member.java
+++ b/src/main/java/naver/webtoon/project/member/entity/Member.java
@@ -37,4 +37,8 @@ public class Member extends Timestamped {
     public void chargePoint(Integer amount){
         this.pointAmount += amount;
     }
+    public void chargeCookie(Integer cookie){
+        this.pointAmount -= 100 * cookie;
+        this.cookieCount += cookie;
+    }
 }

--- a/src/main/java/naver/webtoon/project/transaction/controller/CookieTransactionController.java
+++ b/src/main/java/naver/webtoon/project/transaction/controller/CookieTransactionController.java
@@ -5,6 +5,7 @@ import naver.webtoon.project.common.UserDetailsImpl;
 import naver.webtoon.project.common.response.SuccessMessage;
 import naver.webtoon.project.transaction.dto.request.CookieTransactionChargeRequest;
 import naver.webtoon.project.transaction.dto.request.PointTransactionChargeRequest;
+import naver.webtoon.project.transaction.dto.response.CookieTransactionResponseInfoList;
 import naver.webtoon.project.transaction.dto.response.PointTransactionResponseList;
 import naver.webtoon.project.transaction.service.CookieTransactionService;
 import naver.webtoon.project.transaction.service.PointTransactionService;
@@ -27,9 +28,9 @@ public class CookieTransactionController {
         return new ResponseEntity<>(new SuccessMessage<>("쿠키 충전 성공", null), HttpStatus.CREATED);
     }
 
-    /*@GetMapping
-    public ResponseEntity<SuccessMessage<PointTransactionResponseList>> retireCurrentMemberPointTransactions(@AuthenticationPrincipal UserDetailsImpl userDetails){
-        PointTransactionResponseList response = pointTransactionService.retireCurrentMemberPointTransactions(userDetails.getMember());
-        return new ResponseEntity<>(new SuccessMessage<>("포인트 거래 기록 조회 성공", response), HttpStatus.OK);
-    }*/
+    @GetMapping
+    public ResponseEntity<SuccessMessage<CookieTransactionResponseInfoList>> retireCurrentMemberPointTransactions(@AuthenticationPrincipal UserDetailsImpl userDetails){
+        CookieTransactionResponseInfoList response = cookieTransactionService.retireCurrentMemberCookieTransactions(userDetails.getMember());
+        return new ResponseEntity<>(new SuccessMessage<>("쿠키 거래 기록 조회 성공", response), HttpStatus.OK);
+    }
 }

--- a/src/main/java/naver/webtoon/project/transaction/controller/CookieTransactionController.java
+++ b/src/main/java/naver/webtoon/project/transaction/controller/CookieTransactionController.java
@@ -1,0 +1,35 @@
+package naver.webtoon.project.transaction.controller;
+
+import lombok.RequiredArgsConstructor;
+import naver.webtoon.project.common.UserDetailsImpl;
+import naver.webtoon.project.common.response.SuccessMessage;
+import naver.webtoon.project.transaction.dto.request.CookieTransactionChargeRequest;
+import naver.webtoon.project.transaction.dto.request.PointTransactionChargeRequest;
+import naver.webtoon.project.transaction.dto.response.PointTransactionResponseList;
+import naver.webtoon.project.transaction.service.CookieTransactionService;
+import naver.webtoon.project.transaction.service.PointTransactionService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/cookie-transactions")
+public class CookieTransactionController {
+
+    private final CookieTransactionService cookieTransactionService;
+
+    @PostMapping
+    public ResponseEntity<SuccessMessage<Void>> chargeCookie(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                            @RequestBody CookieTransactionChargeRequest request){
+        cookieTransactionService.chargeCookie(userDetails.getMember(), request);
+        return new ResponseEntity<>(new SuccessMessage<>("쿠키 충전 성공", null), HttpStatus.CREATED);
+    }
+
+    /*@GetMapping
+    public ResponseEntity<SuccessMessage<PointTransactionResponseList>> retireCurrentMemberPointTransactions(@AuthenticationPrincipal UserDetailsImpl userDetails){
+        PointTransactionResponseList response = pointTransactionService.retireCurrentMemberPointTransactions(userDetails.getMember());
+        return new ResponseEntity<>(new SuccessMessage<>("포인트 거래 기록 조회 성공", response), HttpStatus.OK);
+    }*/
+}

--- a/src/main/java/naver/webtoon/project/transaction/dto/request/CookieTransactionChargeRequest.java
+++ b/src/main/java/naver/webtoon/project/transaction/dto/request/CookieTransactionChargeRequest.java
@@ -1,0 +1,39 @@
+package naver.webtoon.project.transaction.dto.request;
+
+import lombok.Getter;
+import naver.webtoon.project.member.entity.Member;
+import naver.webtoon.project.transaction.entity.CookieTransaction;
+import naver.webtoon.project.transaction.entity.PointTransaction;
+import naver.webtoon.project.transaction.entity.Type;
+
+import static naver.webtoon.project.transaction.entity.Type.CHARGE;
+import static naver.webtoon.project.transaction.entity.Type.CONSUME;
+
+@Getter
+public class CookieTransactionChargeRequest {
+    private Integer amount;
+
+    public CookieTransaction toCookieTransaction(Member member){
+        Type type = CHARGE;
+        Integer balance = member.getPointAmount() + amount;
+
+        return CookieTransaction.builder()
+                .amount(amount)
+                .balance(balance)
+                .type(type)
+                .member(member)
+                .build();
+    }
+
+    public PointTransaction toPointTransaction(Member member){
+        Type type = CONSUME;
+        Integer balance = member.getPointAmount() - amount;
+
+        return PointTransaction.builder()
+                .amount(amount)
+                .balance(balance)
+                .type(type)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/naver/webtoon/project/transaction/dto/response/CookieTransactionResponseInfo.java
+++ b/src/main/java/naver/webtoon/project/transaction/dto/response/CookieTransactionResponseInfo.java
@@ -21,7 +21,7 @@ public class CookieTransactionResponseInfo {
         this.cookieTransactionId = cookieTransactionId;
         this.type = type;
         this.amount = amount;
-        this.createdAt = cr가eatedAt;
+        this.createdAt = createdAt;
     }
 
     public static CookieTransactionResponseInfo toResponse(CookieTransaction CookieTransaction){

--- a/src/main/java/naver/webtoon/project/transaction/dto/response/CookieTransactionResponseInfo.java
+++ b/src/main/java/naver/webtoon/project/transaction/dto/response/CookieTransactionResponseInfo.java
@@ -1,0 +1,40 @@
+package naver.webtoon.project.transaction.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import naver.webtoon.project.common.time.TimeConverter;
+import naver.webtoon.project.transaction.entity.CookieTransaction;
+import naver.webtoon.project.transaction.entity.Type;
+
+import java.util.Optional;
+
+@Getter
+public class CookieTransactionResponseInfo {
+
+    private Long cookieTransactionId;
+    private String type;
+    private Integer amount;
+    private String createdAt;
+
+    @Builder
+    public CookieTransactionResponseInfo(Long cookieTransactionId, String type, Integer amount, String createdAt){
+        this.cookieTransactionId = cookieTransactionId;
+        this.type = type;
+        this.amount = amount;
+        this.createdAt = cr가eatedAt;
+    }
+
+    public static CookieTransactionResponseInfo toResponse(CookieTransaction CookieTransaction){
+        String koreanType = Type.toKoreanName(CookieTransaction.getType());
+        String convertedCreatedAt = Optional.ofNullable(CookieTransaction.getCreatedAt())
+                .map(TimeConverter::toStringFormat)
+                .orElse(null);
+
+        return CookieTransactionResponseInfo.builder()
+                .cookieTransactionId(CookieTransaction.getId())
+                .type(koreanType)
+                .amount(CookieTransaction.getAmount())
+                .createdAt(convertedCreatedAt)
+                .build();
+    }
+}

--- a/src/main/java/naver/webtoon/project/transaction/dto/response/CookieTransactionResponseInfoList.java
+++ b/src/main/java/naver/webtoon/project/transaction/dto/response/CookieTransactionResponseInfoList.java
@@ -1,0 +1,25 @@
+package naver.webtoon.project.transaction.dto.response;
+
+import lombok.Getter;
+import naver.webtoon.project.transaction.entity.CookieTransaction;
+import naver.webtoon.project.transaction.entity.PointTransaction;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class CookieTransactionResponseInfoList {
+
+    private List<CookieTransactionResponseInfo> cookieTransactionResponses;
+
+    public CookieTransactionResponseInfoList(List<CookieTransactionResponseInfo> responses){
+        this.cookieTransactionResponses = responses;
+    }
+    public static CookieTransactionResponseInfoList toResponse(List<CookieTransaction> cookieTransactions) {
+        List<CookieTransactionResponseInfo> responseList = cookieTransactions.stream()
+                .map(CookieTransactionResponseInfo::toResponse)
+                .collect(Collectors.toList());
+
+        return new CookieTransactionResponseInfoList(responseList);
+    }
+}

--- a/src/main/java/naver/webtoon/project/transaction/entity/CookieTransaction.java
+++ b/src/main/java/naver/webtoon/project/transaction/entity/CookieTransaction.java
@@ -1,0 +1,25 @@
+package naver.webtoon.project.transaction.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import naver.webtoon.project.member.entity.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CookieTransaction extends Transaction{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cookie_transaction_id")
+    private Long id;
+
+    @Builder
+    public CookieTransaction(Type type, Integer amount, Integer balance, Member member, Long id) {
+        super(type, amount, balance, member);
+        this.id = id;
+    }
+}

--- a/src/main/java/naver/webtoon/project/transaction/repository/CookieTransactionRepository.java
+++ b/src/main/java/naver/webtoon/project/transaction/repository/CookieTransactionRepository.java
@@ -1,0 +1,11 @@
+package naver.webtoon.project.transaction.repository;
+
+import naver.webtoon.project.member.entity.Member;
+import naver.webtoon.project.transaction.entity.CookieTransaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CookieTransactionRepository extends JpaRepository<CookieTransaction, Long> {
+    List<CookieTransaction> findByMember(Member member);
+}

--- a/src/main/java/naver/webtoon/project/transaction/service/CookieTransactionService.java
+++ b/src/main/java/naver/webtoon/project/transaction/service/CookieTransactionService.java
@@ -6,6 +6,7 @@ import naver.webtoon.project.member.entity.Member;
 import naver.webtoon.project.member.repository.MemberRepository;
 import naver.webtoon.project.transaction.dto.request.CookieTransactionChargeRequest;
 import naver.webtoon.project.transaction.dto.request.PointTransactionChargeRequest;
+import naver.webtoon.project.transaction.dto.response.CookieTransactionResponseInfoList;
 import naver.webtoon.project.transaction.dto.response.PointTransactionResponseList;
 import naver.webtoon.project.transaction.entity.CookieTransaction;
 import naver.webtoon.project.transaction.entity.PointTransaction;
@@ -50,10 +51,9 @@ public class CookieTransactionService {
         }
     }
 
-    /*@Transactional(readOnly = true)
-    public PointTransactionResponseList retireCurrentMemberPointTransactions(Member member){
-        List<PointTransaction> pointTransactions = pointTransactionRepository.findByMember(member);
-
-        return PointTransactionResponseList.toResponse(pointTransactions);
-    }*/
+    @Transactional(readOnly = true)
+    public CookieTransactionResponseInfoList retireCurrentMemberCookieTransactions(Member member) {
+        List<CookieTransaction> cookieTransactions = cookieTransactionRepository.findByMember(member);
+        return CookieTransactionResponseInfoList.toResponse(cookieTransactions);
+    }
 }

--- a/src/main/java/naver/webtoon/project/transaction/service/CookieTransactionService.java
+++ b/src/main/java/naver/webtoon/project/transaction/service/CookieTransactionService.java
@@ -1,0 +1,59 @@
+package naver.webtoon.project.transaction.service;
+
+import lombok.RequiredArgsConstructor;
+import naver.webtoon.project.common.exception.WebtoonException;
+import naver.webtoon.project.member.entity.Member;
+import naver.webtoon.project.member.repository.MemberRepository;
+import naver.webtoon.project.transaction.dto.request.CookieTransactionChargeRequest;
+import naver.webtoon.project.transaction.dto.request.PointTransactionChargeRequest;
+import naver.webtoon.project.transaction.dto.response.PointTransactionResponseList;
+import naver.webtoon.project.transaction.entity.CookieTransaction;
+import naver.webtoon.project.transaction.entity.PointTransaction;
+import naver.webtoon.project.transaction.repository.CookieTransactionRepository;
+import naver.webtoon.project.transaction.repository.PointTransactionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static naver.webtoon.project.common.exception.ErrorCode.DEFICIENT_POINT;
+import static naver.webtoon.project.common.exception.ErrorCode.NOT_FOUND_MEMBER;
+
+@Service
+@RequiredArgsConstructor
+public class CookieTransactionService {
+
+    private final CookieTransactionRepository cookieTransactionRepository;
+    private final PointTransactionRepository pointTransactionRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void chargeCookie(Member currentMember, CookieTransactionChargeRequest request) {
+        Member member = memberRepository.findById(currentMember.getId()).orElseThrow(
+                () -> new WebtoonException(NOT_FOUND_MEMBER));
+
+        Integer cookieAmount = request.getAmount();
+        throwIfNotEnoughPoint(cookieAmount, currentMember);
+
+        member.chargeCookie(cookieAmount);
+        CookieTransaction cookieTransaction = request.toCookieTransaction(member);
+        cookieTransactionRepository.save(cookieTransaction);
+
+        PointTransaction pointTransaction = request.toPointTransaction(member);
+        pointTransactionRepository.save(pointTransaction);
+    }
+
+    private void throwIfNotEnoughPoint(Integer cookieAmount, Member currentMember) {
+        Integer essentialAmount = cookieAmount * 100;
+        if(currentMember.getPointAmount() < essentialAmount){
+            throw new WebtoonException(DEFICIENT_POINT);
+        }
+    }
+
+    /*@Transactional(readOnly = true)
+    public PointTransactionResponseList retireCurrentMemberPointTransactions(Member member){
+        List<PointTransaction> pointTransactions = pointTransactionRepository.findByMember(member);
+
+        return PointTransactionResponseList.toResponse(pointTransactions);
+    }*/
+}


### PR DESCRIPTION
### 쿠키 충전, 거래 기록 조회 기능 추가
**CookieTransaction 엔티티 추가**

- Transaction 엔티티를 상속하는 쿠키 거래 엔티티입니다.

**CookieTransactionRepository 클래스 추가**

- 객체를 회원 객체로 찾는 `findByMember()` 메소드를 추가했습니다.

**CookieTransactionController 클래스 추가**

- 쿠키를 충전, 거래 기록 조회 기능을 추가했습니다.

**CookieTransactionService 클래스 추가**

- 쿠키를 충전, 거래 기록 조회 기능을 추가했습니다.
- 쿠키 충전 메서드 로직 설명

1. 로그인한 멤버로 영속화된 멤버를 찾습니다.
2. 멤버가 갖고있는 포인트가 요구하는 포인트(소장권*100) 보다 작다면 예외를 반환합니다.
3. 영속화된 멤버는 갖고있는 포인트 양만큼 소모하고 쿠키를 충전합니다.
4. 쿠키 거래 기록을 저장합니다. (충전)
5. 포인트 거래 기록을 저장합니다. (소모)

**CookieTransactionResponseInfo 클래스 추가**

- 쿠키 거래 기록을 조회할때 필요한 response dto 입니다.

**CookieTransactionResponseInfoList 클래스 추가**

- 쿠키 거래 기록을 조회할때 필요한 response를 리스트로 받는 dto 입니다.

**CookieTransactionChargeRequest 클래스 추가**

- 쿠키 충전할때 필요한 request 입니다.



