### PR TITLE
관심 웹툰 관련 기능 로직 수정

### DIFF
--- a/src/main/java/naver/webtoon/project/webtoon/controller/InterestedWebtoonController.java
+++ b/src/main/java/naver/webtoon/project/webtoon/controller/InterestedWebtoonController.java
@@ -3,6 +3,8 @@ package naver.webtoon.project.webtoon.controller;
 import lombok.RequiredArgsConstructor;
 import naver.webtoon.project.common.UserDetailsImpl;
 import naver.webtoon.project.common.response.SuccessMessage;
+import naver.webtoon.project.webtoon.dto.response.InterestedWebtoonInfoResponse;
+import naver.webtoon.project.webtoon.dto.response.InterestedWebtoonInfoResponseList;
 import naver.webtoon.project.webtoon.service.InterestedWebtoonService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,5 +30,12 @@ public class InterestedWebtoonController {
     public ResponseEntity<SuccessMessage<Void>> deleteInterestedWebtoon(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long webtoonId) {
         interestedWebtoonService.deleteInterestedWebtoon(userDetails.getMember(), webtoonId);
         return new ResponseEntity<>(new SuccessMessage<>("관심웹툰삭제성공", null), HttpStatus.OK);
+    }
+
+    //관심웹툰조회
+    @GetMapping("/interested-webtoons")
+    public ResponseEntity<SuccessMessage<InterestedWebtoonInfoResponseList>> retrieveInterestedWebtoonsByMember(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        InterestedWebtoonInfoResponseList response = interestedWebtoonService.retrieveInterestedWebtoonsByMember(userDetails.getMember());
+        return new ResponseEntity<>(new SuccessMessage<>("관심에피소드리스트조회성공", response), HttpStatus.OK);
     }
 }

--- a/src/main/java/naver/webtoon/project/webtoon/dto/request/WebtoonRegisterRequest.java
+++ b/src/main/java/naver/webtoon/project/webtoon/dto/request/WebtoonRegisterRequest.java
@@ -24,11 +24,13 @@ public class WebtoonRegisterRequest {
     private String thumbnail;
     @NotNull
     private String serializedStatus;
+    private Integer totalViewCount;
+    private Integer likeCount;
     @NotNull
     private List<String> publishingDay;
     private List<String> hashTag;
 
-    public WebtoonRegisterRequest(String title, String author, String description, String thumbnail, String serializedStatus, List<String> publishingDay, List<String> hashTag) {
+    public WebtoonRegisterRequest(String title, String author, String description, String thumbnail, String serializedStatus ,List<String> publishingDay, List<String> hashTag) {
         this.title = title;
         this.author = author;
         this.description = description;
@@ -47,6 +49,8 @@ public class WebtoonRegisterRequest {
                 .author(author)
                 .description(description)
                 .thumbnail(thumbnail)
+                .totalViewCount(0)
+                .likeCount(0)
                 .serializedStatus(serializedStatusEnum)
                 .build();
     }

--- a/src/main/java/naver/webtoon/project/webtoon/dto/response/InterestedWebtoonInfoResponse.java
+++ b/src/main/java/naver/webtoon/project/webtoon/dto/response/InterestedWebtoonInfoResponse.java
@@ -1,0 +1,66 @@
+package naver.webtoon.project.webtoon.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import naver.webtoon.project.common.time.TimeConverter;
+import naver.webtoon.project.webtoon.entity.InterestedWebtoon;
+import naver.webtoon.project.webtoon.entity.Webtoon;
+import naver.webtoon.project.webtoon.entity.enums.SerializedStatus;
+
+import java.util.Optional;
+
+@Getter
+public class InterestedWebtoonInfoResponse {
+    private Long interestedWebtoonId;
+    private Long webtoonId;
+    private String title;
+    private String author;
+    private String thumbnail;
+    private String serializedStatus;
+    private Integer likeCount;
+    private Integer totalViewCount;
+    private String updatedAt;
+
+    @Builder
+    public InterestedWebtoonInfoResponse(Long interestedWebtoonId,
+                                        Long webtoonId,
+                                        String title,
+                                        String author,
+                                        String thumbnail,
+                                        String serializedStatus,
+                                        Integer likeCount,
+                                        Integer totalViewCount,
+                                        String updatedAt){
+        this.interestedWebtoonId = interestedWebtoonId;
+        this.webtoonId = webtoonId;
+        this.title = title;
+        this.author = author;
+        this.thumbnail = thumbnail;
+        this.serializedStatus = serializedStatus;
+        this.likeCount = likeCount;
+        this.totalViewCount = totalViewCount;
+        this.updatedAt = updatedAt;
+    }
+
+    public static InterestedWebtoonInfoResponse toResponse(InterestedWebtoon interestedWebtoon){
+        Webtoon webtoon = interestedWebtoon.getWebtoon();
+
+        SerializedStatus serializedStatus = SerializedStatus.toEnum(String.valueOf(webtoon.getSerializedStatus()));
+        String convertUpdateAt = Optional.ofNullable(webtoon.getUpdatedAt())
+                .map(TimeConverter::toStringFormat)
+                .orElse(null);
+
+        return InterestedWebtoonInfoResponse.builder()
+                .interestedWebtoonId(interestedWebtoon.getId())
+                .webtoonId(webtoon.getId())
+                .title(webtoon.getTitle())
+                .author(webtoon.getAuthor().getName())
+                .thumbnail(webtoon.getThumbnail())
+                .serializedStatus(String.valueOf(serializedStatus))
+                .likeCount(webtoon.getLikeCount())
+                .totalViewCount(webtoon.getTotalViewCount())
+                .updatedAt(convertUpdateAt)
+                .build();
+
+    }
+}

--- a/src/main/java/naver/webtoon/project/webtoon/dto/response/InterestedWebtoonInfoResponseList.java
+++ b/src/main/java/naver/webtoon/project/webtoon/dto/response/InterestedWebtoonInfoResponseList.java
@@ -1,0 +1,24 @@
+package naver.webtoon.project.webtoon.dto.response;
+
+import lombok.Getter;
+import naver.webtoon.project.webtoon.entity.InterestedWebtoon;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class InterestedWebtoonInfoResponseList {
+    private List<InterestedWebtoonInfoResponse> interestedWebtoonInfoResponses;
+
+    public InterestedWebtoonInfoResponseList(List<InterestedWebtoonInfoResponse> responses){
+        this.interestedWebtoonInfoResponses = responses;
+    }
+
+    public static InterestedWebtoonInfoResponseList toResponse(List<InterestedWebtoon> interestedWebtoons){
+        List<InterestedWebtoonInfoResponse> webtoonInfos = interestedWebtoons.stream()
+                .map(InterestedWebtoonInfoResponse::toResponse)
+                .collect(Collectors.toList());
+
+        return new InterestedWebtoonInfoResponseList(webtoonInfos);
+    }
+}

--- a/src/main/java/naver/webtoon/project/webtoon/entity/Webtoon.java
+++ b/src/main/java/naver/webtoon/project/webtoon/entity/Webtoon.java
@@ -32,6 +32,8 @@ public class Webtoon extends Timestamped {
 
     @Column(nullable = false)
     private Integer totalViewCount;
+    @Column(nullable = false)
+    private Integer likeCount;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
@@ -44,10 +46,12 @@ public class Webtoon extends Timestamped {
     @OneToMany(mappedBy = "webtoon", cascade = CascadeType.ALL)
     private List<InterestedWebtoon> interestedWebtoon;
     @Builder
-    public Webtoon(String title, String thumbnail, String description, SerializedStatus serializedStatus, Author author) {
+    public Webtoon(String title, String thumbnail, String description, Integer totalViewCount, Integer likeCount ,SerializedStatus serializedStatus, Author author) {
         this.title = title;
         this.thumbnail = thumbnail;
         this.description = description;
+        this.totalViewCount = totalViewCount;
+        this.likeCount = likeCount;
         this.serializedStatus = serializedStatus;
         this.author = author;
     }
@@ -62,5 +66,13 @@ public class Webtoon extends Timestamped {
 
     public void incrementTotalViewCount(){
         this.totalViewCount++;
+    }
+
+    public void incrementLikeCount(){
+        this.likeCount++;
+    }
+
+    public void decrementLikeCount(){
+        this.likeCount--;
     }
 }

--- a/src/main/java/naver/webtoon/project/webtoon/repository/InterestedWebtoonRepository.java
+++ b/src/main/java/naver/webtoon/project/webtoon/repository/InterestedWebtoonRepository.java
@@ -5,11 +5,14 @@ import naver.webtoon.project.webtoon.entity.InterestedWebtoon;
 import naver.webtoon.project.webtoon.entity.Webtoon;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface InterestedWebtoonRepository extends JpaRepository<InterestedWebtoon, Long> {
 
-    boolean existsByMemberAndWebtoon(Member member, Webtoon webtoon);
-
     Optional<InterestedWebtoon> findByMemberAndWebtoon(Member currentMember, Webtoon webtoon);
+
+    boolean existsByMemberIdAndWebtoonId(Long memberId, Long webtoonId);
+
+    List<InterestedWebtoon> findByMemberId(Long id);
 }

--- a/src/main/java/naver/webtoon/project/webtoon/service/InterestedWebtoonService.java
+++ b/src/main/java/naver/webtoon/project/webtoon/service/InterestedWebtoonService.java
@@ -4,12 +4,15 @@ import lombok.RequiredArgsConstructor;
 import naver.webtoon.project.common.UserDetailsImpl;
 import naver.webtoon.project.common.exception.WebtoonException;
 import naver.webtoon.project.member.entity.Member;
+import naver.webtoon.project.webtoon.dto.response.InterestedWebtoonInfoResponseList;
 import naver.webtoon.project.webtoon.entity.InterestedWebtoon;
 import naver.webtoon.project.webtoon.entity.Webtoon;
 import naver.webtoon.project.webtoon.repository.InterestedWebtoonRepository;
 import naver.webtoon.project.webtoon.repository.WebtoonRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static naver.webtoon.project.common.exception.ErrorCode.*;
 
@@ -22,16 +25,17 @@ public class InterestedWebtoonService {
 
     @Transactional
     public void registerInterestedWebtoon(Member currentMember, Long webtoonId) {
+        throwIfDuflicatedInterestedWebtoon(currentMember.getId(), webtoonId);
         Webtoon webtoon = webtoonRepository.findById(webtoonId).orElseThrow(
                 () -> new WebtoonException(NOT_FOUND_WEBTOON));
-        throwIfDuflicatedInterestedWebtoon(currentMember, webtoon);
 
         InterestedWebtoon interestedWebtoon = InterestedWebtoon.updateInterestedWebtoon(currentMember, webtoon);
+        webtoon.incrementLikeCount();
         interestedWebtoonRepository.save(interestedWebtoon);
     }
 
-    private void throwIfDuflicatedInterestedWebtoon(Member member, Webtoon webtoon) {
-        if (interestedWebtoonRepository.existsByMemberAndWebtoon(member, webtoon)) {
+    private void throwIfDuflicatedInterestedWebtoon(Long memberId, Long webtoonId) {
+        if (interestedWebtoonRepository.existsByMemberIdAndWebtoonId(memberId, webtoonId)) {
             throw new WebtoonException(DUPLICATE_INTERESTED_WEBTOON);
         }
     }
@@ -45,6 +49,13 @@ public class InterestedWebtoonService {
                 () -> new WebtoonException(NOT_FOUND_INTERESTED_WEBTOON)
         );
 
+        webtoon.decrementLikeCount();
         interestedWebtoonRepository.delete(interestedWebtoon);
+    }
+
+    @Transactional(readOnly = true)
+    public InterestedWebtoonInfoResponseList retrieveInterestedWebtoonsByMember(Member member) {
+        List<InterestedWebtoon> interestedWebtoons = interestedWebtoonRepository.findByMemberId(member.getId());
+        return InterestedWebtoonInfoResponseList.toResponse(interestedWebtoons);
     }
 }


### PR DESCRIPTION
### 관심 웹툰 관련 기능 로직 수정
**추가된 기능**

- 등록된 관심 웹툰 리스트 조회 기능

**로직 수정된 기능**

- 관심 웹툰 등록 기능
- 등록된 관심 웹툰 삭제 기능 

**관심웹툰관련 기능 로직 수정된 내용**

1. 관심 웹툰 등록 기능
- 관심 웹툰 등록 시 웹툰의 총 좋아요 수를 증가시킵니다.

- 원래 로직
  - webtoon 엔티티에 likeCount(좋아요) 컬럼이 없고, interestedWebtoon 테이블에만 등록하는 로직

 - 수정된 로직
   - 관심 웹툰 등록 시 웹툰의 총 좋아요 수를 증가 -> webtoon 엔티티에 likeCount(좋아요) 컬럼 추가

2. 관심 등록된 웹툰 삭제 기능
- 관심 웹툰 등록 시 웹툰의 총 좋아요 수를 감소시킵니다.

- 원래 로직
  - webtoon 엔티티에 likeCount(좋아요) 컬럼이 없고, interestedWebtoon 테이블에만 삭제하는 로직

 - 수정된 로직
   - 관심 웹툰 등록 시 웹툰의 총 좋아요 수를 감소

**InterestedWebtoonInfoResponse 클래스 추가 **

- 관심 웹툰 조회 시 응답형식인 response dto입니다.

**InterestedWebtoonInfoResponseList 클래스 추가**

- InterestedWebtoonInfoResponse를 List로 받는 response dto입니다.

**InterestedWebtoonController 클래스 관심웹툰리스트조회 기능 추가**

- `retrieveInterestedWebtoonsByMember` : 관심웹툰리스트조회 기능 메서드입니다.

**InterestedWebtoonService클래스 관심웹툰리스트조회 기능 추가**

- `retrieveInterestedWebtoonsByMember` : 관심웹툰리스트조회 기능 메서드입니다.

**InterestedWebtoonRepository클래스 관심웹툰리스트조회 기능 추가**

- `findByMemberId` : 회원 id로 관심 웹툰 List를 찾습니다.

