### PR TITLE
동시성 제어 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.redisson:redisson-spring-boot-starter:3.35.0'
+	implementation 'org.redisson:redisson:3.20.0'
 
 	runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
 	compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
@@ -36,6 +36,7 @@ dependencies {
 	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.redisson:redisson-spring-boot-starter:3.35.0'
 
 	runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/src/main/java/naver/webtoon/project/common/exception/ErrorCode.java
+++ b/src/main/java/naver/webtoon/project/common/exception/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
     NOT_FOUND_INTERESTED_WEBTOON(HttpStatus.NOT_FOUND, "INTERESTED_WEBTOON_001", "찾을 수 없는 관심 웹툰입니다."),
     DUPLICATE_INTERESTED_WEBTOON(HttpStatus.BAD_REQUEST, "INTERESTED_WEBTOON_002", "관심 웹툰은 중복될 수 없습니다."),
 
+    NOT_AVAILABLE_LOCK(HttpStatus.CONFLICT, "CONCURRENCY_001", "락 획득이 불가능 합니다.")
     ;
 
 

--- a/src/main/java/naver/webtoon/project/common/redis/config/RockRedisConfig.java
+++ b/src/main/java/naver/webtoon/project/common/redis/config/RockRedisConfig.java
@@ -1,0 +1,17 @@
+package naver.webtoon.project.common.redis.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RockRedisConfig {
+
+    @Bean(destroyMethod = "shutdown")
+    public RedissonClient redisson(){
+        return Redisson.create();
+    }
+}

--- a/src/main/java/naver/webtoon/project/episode/service/OwnedEpisodeService.java
+++ b/src/main/java/naver/webtoon/project/episode/service/OwnedEpisodeService.java
@@ -15,10 +15,13 @@ import naver.webtoon.project.member.repository.MemberRepository;
 import naver.webtoon.project.transaction.entity.CookieTransaction;
 import naver.webtoon.project.transaction.repository.CookieTransactionRepository;
 import naver.webtoon.project.webtoon.entity.Webtoon;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static naver.webtoon.project.common.exception.ErrorCode.*;
 import static naver.webtoon.project.episode.entity.PaymentType.FREE;
@@ -32,29 +35,47 @@ public class OwnedEpisodeService {
     private final OwnedEpisodeRepository ownedEpisodeRepository;
     private final CookieTransactionRepository cookieTransactionRepository;
     private final RedisService redisService;
+    private final RedissonClient redissonClient;
 
     @Transactional
     public void buyEpisode(Member currentMember, Long episodeId) {
-        Member member = memberRepository.findById(currentMember.getId()).orElseThrow(
-                () -> new WebtoonException(NOT_FOUND_MEMBER));
-        Episode episode = episodeRepository.findById(episodeId).orElseThrow(
-                () -> new WebtoonException(NOT_FOUND_EPISODE));
+        String lockName = "buy-episode" + " / " + "username: " + currentMember.getUsername() + "episodeId: " + episodeId;
+        RLock lock = redissonClient.getLock(lockName);
 
-        if (ownedEpisodeRepository.existsByMemberAndEpisode(member, episode)) {
-            throw new WebtoonException(DUPLICATION_OWNED_EPISODE);
+        try{
+            boolean isLocked = lock.tryLock(2, 5, TimeUnit.SECONDS);
+            if(!isLocked){
+                throw new WebtoonException(NOT_AVAILABLE_LOCK);
+            }
+
+            Member member = memberRepository.findById(currentMember.getId()).orElseThrow(
+                    () -> new WebtoonException(NOT_FOUND_MEMBER));
+            Episode episode = episodeRepository.findById(episodeId).orElseThrow(
+                    () -> new WebtoonException(NOT_FOUND_EPISODE));
+
+            if (ownedEpisodeRepository.existsByMemberAndEpisode(member, episode)) {
+                throw new WebtoonException(DUPLICATION_OWNED_EPISODE);
+            }
+
+            int availableCookie = member.getCookieCount();
+            int requiredCookieAmount = episode.getNeededCookieAmount();
+
+            throwIfNotEnoughCookie(availableCookie, requiredCookieAmount);
+
+            member.consumeCookie(requiredCookieAmount);
+            OwnedEpisode ownedEpisode = OwnedEpisode.createOwenEpisode(member, episode);
+            ownedEpisodeRepository.save(ownedEpisode);
+
+            CookieTransaction cookieTransaction = CookieTransaction.createConsumeCookieTransaction(member, requiredCookieAmount);
+            cookieTransactionRepository.save(cookieTransaction);
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            if (lock.isLocked() && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
         }
-
-        int availableCookie = member.getCookieCount();
-        int requiredCookieAmount = episode.getNeededCookieAmount();
-
-        throwIfNotEnoughCookie(availableCookie, requiredCookieAmount);
-
-        member.consumeCookie(requiredCookieAmount);
-        OwnedEpisode ownedEpisode = OwnedEpisode.createOwenEpisode(member, episode);
-        ownedEpisodeRepository.save(ownedEpisode);
-
-        CookieTransaction cookieTransaction = CookieTransaction.createConsumeCookieTransaction(member, requiredCookieAmount);
-        cookieTransactionRepository.save(cookieTransaction);
     }
 
     private void throwIfNotEnoughCookie(int availableCookie, int requiredCookieAmount) {

--- a/src/main/java/naver/webtoon/project/transaction/service/CookieTransactionService.java
+++ b/src/main/java/naver/webtoon/project/transaction/service/CookieTransactionService.java
@@ -10,13 +10,15 @@ import naver.webtoon.project.transaction.entity.CookieTransaction;
 import naver.webtoon.project.transaction.entity.PointTransaction;
 import naver.webtoon.project.transaction.repository.CookieTransactionRepository;
 import naver.webtoon.project.transaction.repository.PointTransactionRepository;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
-import static naver.webtoon.project.common.exception.ErrorCode.DEFICIENT_POINT;
-import static naver.webtoon.project.common.exception.ErrorCode.NOT_FOUND_MEMBER;
+import static naver.webtoon.project.common.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -25,21 +27,39 @@ public class CookieTransactionService {
     private final CookieTransactionRepository cookieTransactionRepository;
     private final PointTransactionRepository pointTransactionRepository;
     private final MemberRepository memberRepository;
+    private final RedissonClient redissonClient;
 
     @Transactional
     public void chargeCookie(Member currentMember, CookieTransactionChargeRequest request) {
-        Member member = memberRepository.findById(currentMember.getId()).orElseThrow(
-                () -> new WebtoonException(NOT_FOUND_MEMBER));
+        String lockName = "charge-cookie" + " / " + "username: " + currentMember.getUsername();
+        RLock lock = redissonClient.getLock(lockName);
 
-        Integer cookieAmount = request.getAmount();
-        throwIfNotEnoughPoint(cookieAmount, currentMember);
+        try{
+            boolean isLocked = lock.tryLock(2, 5, TimeUnit.SECONDS);
+            if(!isLocked){
+                throw new WebtoonException(NOT_AVAILABLE_LOCK);
+            }
 
-        member.chargeCookie(cookieAmount);
-        CookieTransaction cookieTransaction = request.toCookieTransaction(member);
-        cookieTransactionRepository.save(cookieTransaction);
+            Member member = memberRepository.findById(currentMember.getId()).orElseThrow(
+                    () -> new WebtoonException(NOT_FOUND_MEMBER));
 
-        PointTransaction pointTransaction = request.toPointTransaction(member);
-        pointTransactionRepository.save(pointTransaction);
+            Integer cookieAmount = request.getAmount();
+            throwIfNotEnoughPoint(cookieAmount, currentMember);
+
+            member.chargeCookie(cookieAmount);
+            CookieTransaction cookieTransaction = request.toCookieTransaction(member);
+            cookieTransactionRepository.save(cookieTransaction);
+
+            PointTransaction pointTransaction = request.toPointTransaction(member);
+            pointTransactionRepository.save(pointTransaction);
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            if (lock.isLocked() && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
     }
 
     private void throwIfNotEnoughPoint(Integer cookieAmount, Member currentMember) {

--- a/src/main/java/naver/webtoon/project/transaction/service/PointTransactionService.java
+++ b/src/main/java/naver/webtoon/project/transaction/service/PointTransactionService.java
@@ -9,11 +9,15 @@ import naver.webtoon.project.transaction.dto.request.PointTransactionChargeReque
 import naver.webtoon.project.transaction.dto.response.PointTransactionResponseList;
 import naver.webtoon.project.transaction.entity.PointTransaction;
 import naver.webtoon.project.transaction.repository.PointTransactionRepository;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import static naver.webtoon.project.common.exception.ErrorCode.NOT_AVAILABLE_LOCK;
 import static naver.webtoon.project.common.exception.ErrorCode.NOT_FOUND_MEMBER;
 
 @Service
@@ -22,6 +26,7 @@ public class PointTransactionService {
 
     private final PointTransactionRepository pointTransactionRepository;
     private final MemberRepository memberRepository;
+    private final RedissonClient redissonClient;
 
     @Transactional(readOnly = true)
     public PointTransactionResponseList retireCurrentMemberPointTransactions(Member member){
@@ -32,11 +37,28 @@ public class PointTransactionService {
 
     @Transactional
     public void chargePoint(Member currentMember, PointTransactionChargeRequest request) {
-        Member member = memberRepository.findById(currentMember.getId()).orElseThrow(
-                () -> new WebtoonException(NOT_FOUND_MEMBER));
+        String lockName = "charge-point" + " / " + "username: " + currentMember.getUsername();
+        RLock lock = redissonClient.getLock(lockName);
 
-        member.chargePoint(request.getAmount());
-        PointTransaction pointTransaction = request.toPointTransaction(member);
-        pointTransactionRepository.save(pointTransaction);
+        try{
+            boolean isLocked = lock.tryLock(2, 5, TimeUnit.SECONDS);
+            if(!isLocked){
+                throw new WebtoonException(NOT_AVAILABLE_LOCK);
+            }
+
+            Member member = memberRepository.findById(currentMember.getId()).orElseThrow(
+                    () -> new WebtoonException(NOT_FOUND_MEMBER));
+
+            member.chargePoint(request.getAmount());
+            PointTransaction pointTransaction = request.toPointTransaction(member);
+            pointTransactionRepository.save(pointTransaction);
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            if (lock.isLocked() && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
     }
 }


### PR DESCRIPTION
### 동시성 제어 코드 작성

결제 서비스 이용 시 동시성 제어 코드가 필요합니다.
Redis가 지원하는 라이브러리인 Redisson을 선택하여 동시성 문제를 해결하였습니다.

- `LockRedisConfig` 클래스 추가 및 코드 작성
- `PointTransactionService` 코드 작성

- `chargePoint`에 동시성 제어 코드 추가

        @Transactional
        public void chargePoint(Member currentMember, PointTransactionChargeRequest request) {
            String lockName = "charge-point" + " / " + "username: " + currentMember.getUsername();
            RLock lock = redissonClient.getLock(lockName);

        try{
            boolean isLocked = lock.tryLock(2, 5, TimeUnit.SECONDS);
            if(!isLocked){
                throw new WebtoonException(NOT_AVAILABLE_LOCK);
            }

            Member member = memberRepository.findById(currentMember.getId()).orElseThrow(
                    () -> new WebtoonException(NOT_FOUND_MEMBER));

            member.chargePoint(request.getAmount());
            PointTransaction pointTransaction = request.toPointTransaction(member);
            pointTransactionRepository.save(pointTransaction);

        } catch (InterruptedException e) {
            Thread.currentThread().interrupt();
        } finally {
            if (lock.isLocked() && lock.isHeldByCurrentThread()) {
                lock.unlock();
            }
        }
    }

`CookieTransactionService` 코드 작성
- `chargeCookie`에 동시성 제어 코드 추가

        @Transactional
        public void chargeCookie(Member currentMember, CookieTransactionChargeRequest request) {
            String lockName = "charge-cookie" + " / " + "username: " + currentMember.getUsername();
            RLock lock = redissonClient.getLock(lockName);

        try{
            boolean isLocked = lock.tryLock(2, 5, TimeUnit.SECONDS);
            if(!isLocked){
                throw new WebtoonException(NOT_AVAILABLE_LOCK);
            }

            Member member = memberRepository.findById(currentMember.getId()).orElseThrow(
                    () -> new WebtoonException(NOT_FOUND_MEMBER));

            Integer cookieAmount = request.getAmount();
            throwIfNotEnoughPoint(cookieAmount, currentMember);

            member.chargeCookie(cookieAmount);
            CookieTransaction cookieTransaction = request.toCookieTransaction(member);
            cookieTransactionRepository.save(cookieTransaction);

            PointTransaction pointTransaction = request.toPointTransaction(member);
            pointTransactionRepository.save(pointTransaction);

        } catch (InterruptedException e) {
            Thread.currentThread().interrupt();
        } finally {
            if (lock.isLocked() && lock.isHeldByCurrentThread()) {
                lock.unlock();
            }
        }

- `OwnedEpisodeService` 코드 작성
- `buyEpisode` 에 동시성 제어 코드 추가

        @Transactional
        public void buyEpisode(Member currentMember, Long episodeId) {
            String lockName = "buy-episode" + " / " + "username: " + currentMember.getUsername() + "episodeId: " + episodeId;
            RLock lock = redissonClient.getLock(lockName);

        try{
            boolean isLocked = lock.tryLock(2, 5, TimeUnit.SECONDS);
            if(!isLocked){
                throw new WebtoonException(NOT_AVAILABLE_LOCK);
            }

            Member member = memberRepository.findById(currentMember.getId()).orElseThrow(
                    () -> new WebtoonException(NOT_FOUND_MEMBER));
            Episode episode = episodeRepository.findById(episodeId).orElseThrow(
                    () -> new WebtoonException(NOT_FOUND_EPISODE));

            if (ownedEpisodeRepository.existsByMemberAndEpisode(member, episode)) {
                throw new WebtoonException(DUPLICATION_OWNED_EPISODE);
            }

            int availableCookie = member.getCookieCount();
            int requiredCookieAmount = episode.getNeededCookieAmount();

            throwIfNotEnoughCookie(availableCookie, requiredCookieAmount);

            member.consumeCookie(requiredCookieAmount);
            OwnedEpisode ownedEpisode = OwnedEpisode.createOwenEpisode(member, episode);
            ownedEpisodeRepository.save(ownedEpisode);

            CookieTransaction cookieTransaction = CookieTransaction.createConsumeCookieTransaction(member, requiredCookieAmount);
            cookieTransactionRepository.save(cookieTransaction);

        } catch (InterruptedException e) {
            Thread.currentThread().interrupt();
        } finally {
            if (lock.isLocked() && lock.isHeldByCurrentThread()) {
                lock.unlock();
            }
        }
    }

**동시성 문제 해결법 종류 알아보기**

여러 사용자가 동시에 결제를 시도하는 경우, 같은 결제 거래가 중복으로 발생할 수 있습니다. 이는 사용자에게 큰 불편을 주고, 서비스의 신뢰도를 하락 시키는 큰 오류이기 때문에 꼭 해결해야 하는 문제입니다.

동시성 문제 해결 방법에는 여러가지 방법이 있습니다. 최근 서비스는 대규모 분산 시스템을 이용하므로 분산락을 구현해야 합니다. 따라서 애플리케이션 내에서 처리하는 해결 방식은 적합하지 않다 생각하였습니다. 다양한 분산락 방법이 있지만 이미 인프라가 구축되어 있는 MYSQL과 Redis를 사용할 수 있습니다.

[MySQL]

MySQL을 이용한 DB락은 낙관적 락, 비관적 락, 네임드 락을 사용할 수 있다.

낙관적 락은 데이터를 변경할 때 데이터의 버전을 체크하여 변경 가능 여부를 판단하고, 변경시 락을 거는 방식입니다. 락을 걸어 충돌을 예방하기 때문에 데이터 정합성을 보장받을 수 있으나, 락을 걸면 성능이 저하합니다.

비관적 락은 데이터를 읽거나 변경할 때 락을 걸어 다른 사용자가 해당 데이터를 사용하지 못하도록 제어하는 방식입니다. 락을 걸어 충돌을 예방하기 때문에 데이터 정합성을 보장받을 수 있으나, 락을 걸면 성능이 저하됩니다.

네임드 락은 특정 이름을 가진 락을 생성하고, 해당 이름을 가진 락이 존재하는 경우에는 락 획득 전까지 다른 사용자가 접근하지 못하도록 제어하는 방식입니다. 독립적인 리소스에 락을 걸어 다른 리소스에 영향을 주지 않지만, 별도의 명령어로 해제/선점 시간이 끝나야 락이 해제됩니다. 이는 Connection Pool이 부족해질 수 있는 오류가 있습니다.

[Redis]
Redis를 이용한 DB락은 두가지 라이브러리인 Lettuce와 Redisson를 사용할 수 있습니다.

Lettuce는 Lock-Unlock 과정이 짧아서 락 하는 경우가 드문 경우에는 유용합니다. 하지만 타임 아웃이 지정되지 있지 않아 개발자가 직접 구현해야 하고, 스핀락을 사용한 구현 기법으로 락을 획득하지 못한 경우 Redis에게 락을 획득하기 위해 계속 요청을 보내서 Redis에 부하가 발생할 수 있습니다.

Redisson은 Lock에 타임 아웃을 지정할 수 있어 무한정 대기 상태로 빠질 수 있는 위험이 없습니다. 또한 pub/sub 기능을 사용하여 Redis에 부하를 줄일 수 있습니다.

[Publish/Subscrib란]?

- 특정한 주제(topic)에 대하여 topic을 구독한 모두에게 메세지를 발행하는 통신 방법
  - 채널을 구독한 수신자 모두에게 메세지를 전송하는 것을 의미

[pub/sub 기능을 이용한 Redisson의 Lock 획득 프로세스]

- tryLock을 호출하여 락 획득에 성공하면 True 반환
- pub/sub을 이용하여 메세지가 올 때 까지 대기하다 락이 해제되었다는 메세지가 오면 대기를 풀고 다시 락 획득 시도
  - 락 획득에 실패하면 다시 락 해제 메세지를 기다림
  - 타임 아웃 시 까지 위 프로세스를 반복하다 타임아웃 시간이 지나면 최종적으로 false를 반환하고 락 획득에 실패했음을 알림

[트레이드오프]

Redis는 인메모리 기반의 데이터베이스로 디스크 기반의 MySQL보다 빠른 속도를 지원합니다. Redisson 라이브러리를 사용하면 타임아웃 기능(TTL)을 활용하여 데드락을 방지할 수 있으며, pub/sub 기능으로 Reids에 부하를 줄이면서 동시성 제어를 수행할 수 있습니다.

이러한 이점들을 고려하여 Redisson을 이용하여 동시성 제어를 구현하였습니다.
